### PR TITLE
Added support for custom token types

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -54,3 +54,5 @@ YYYY/MM/DD, github id, Full name, email
 2015/11/09, parrt, Terence Parr, parrt@antlr.org
 2016/02/23, yegorpetrov, Yegor Petrov, petrov.yegor@gmail.com
 2016/03/12, vemilyus, Alexander Katlein, mail@vemilyus.com
+2016/04/01, Filippok, Philipp Mirzayants, filsoftw@gmail.com
+

--- a/src/org/antlr/jetbrains/adaptor/lexer/IANTLRTokenBase.java
+++ b/src/org/antlr/jetbrains/adaptor/lexer/IANTLRTokenBase.java
@@ -1,0 +1,8 @@
+package org.antlr.jetbrains.adaptor.lexer;
+
+/**
+ * Base interface for token to support custom token types.
+ */
+public interface IANTLRTokenBase {
+	int getANTLRTokenType();
+}

--- a/src/org/antlr/jetbrains/adaptor/lexer/PSITokenSource.java
+++ b/src/org/antlr/jetbrains/adaptor/lexer/PSITokenSource.java
@@ -48,7 +48,7 @@ public class PSITokenSource implements TokenSource {
 	public Token nextToken() {
 		ProgressIndicatorProvider.checkCanceled();
 
-		TokenIElementType ideaTType = (TokenIElementType)builder.getTokenType();
+		IANTLRTokenBase ideaTType = (IANTLRTokenBase) builder.getTokenType();
 		int type = ideaTType!=null ? ideaTType.getANTLRTokenType() : Token.EOF;
 
 		int channel = Token.DEFAULT_CHANNEL;

--- a/src/org/antlr/jetbrains/adaptor/lexer/TokenIElementType.java
+++ b/src/org/antlr/jetbrains/adaptor/lexer/TokenIElementType.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
  *  We differentiate between parse tree subtree roots and tokens with
  *  {@link RuleIElementType} and {@link TokenIElementType}, respectively.
  */
-public class TokenIElementType extends IElementType {
+public class TokenIElementType extends IElementType implements IANTLRTokenBase {
 	private final int antlrTokenType;
 
 	public TokenIElementType(int antlrTokenType,


### PR DESCRIPTION
To support multiple languages in one file we need to extend ILazyParseableElementType. With this fix we can achieve this goal like this:

``` java
public class ScriptElementType extends ILazyParseableElementType implements IANTLRTokenBase
{
    private int antlrTokenId;

    public ScriptElementType(@NotNull @NonNls String debugName, int tokenId)
    {
        super(debugName, ScriptLanguage.INSTANCE);
        antlrTokenId = tokenId;
    }

    @Override
    public int getANTLRTokenType()
    {
        return antlrTokenId;
    }
}


public class MarkupLexerAdapter extends ANTLRLexerAdaptor
{
    public MarkupLexerAdapter(Language language, Lexer lexer)
    {
        super(language, lexer);
    }

    @Nullable
    @Override
    public IElementType getTokenType(int antlrTokenType)
    {
        if (antlrTokenType == MarkupLexer.SCRIPT)
        {
            return new ScriptElementType("SCRIPT", antlrTokenType);
        }
        return super.getTokenType(antlrTokenType);
    }
}
```
